### PR TITLE
[+] Remove query parameters as well from URL

### DIFF
--- a/src/Utils/Utils.js
+++ b/src/Utils/Utils.js
@@ -27,7 +27,7 @@ var Utils = {
    * @return {String} newCleanUrl
    */
   cleanLink: function(url) {
-    return url.replace(/#.*/, '');
+    return url.replace(/(#.*|\?.*)/, '');
   },
 
   /**


### PR DESCRIPTION
`Utils.cleanUrl` also removes query parameters (strings starting with `?`)
Example Regexr: https://regexr.com/436ha