### PR TITLE
fix(core): :bug: Clean url extend

### DIFF
--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -99,9 +99,9 @@ export const parseQuery = (str: string) =>
   }, {});
 
 /**
- * Clean URL, remove "hash".
+ * Clean URL, remove "hash" and/or "trailing slash".
  */
-export const clean = (url: string) => url.replace(/#.*/, '');
+export const clean = (url: string) => url.replace(/(\/#.*|\/|#.*)$/, '');
 /**
  * Clean URL, remove "origin".
  */


### PR DESCRIPTION
Previously two url could be the same origin and therefore trigger a transition instead of a default handler.

### New behavior:
Every of the following URL will be considered as the SAME URL and will trigger a default behavior:
- `//toto.com`
- `//toto.com/`
- `//toto.com/#`
- `//toto.com/#hash`

### Motivation
You can read the #404 to see my motivation.
Url with or without traling slash should not trigger two differents behavior.

This PR fixes #404 