### PR TITLE
Keeping full path url in the current / next data

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@commitlint/config-conventional": "8.1.0",
     "@commitlint/config-lerna-scopes": "8.1.0",
     "@types/jest": "^24.0.11",
+    "@types/lodash": "^4.14.139",
     "all-contributors-cli": "thierrymichel/all-contributors-cli",
     "babel-eslint": "^10.0.1",
     "commitizen": "4.0.3",

--- a/packages/core/__tests__/core/core.init.test.ts
+++ b/packages/core/__tests__/core/core.init.test.ts
@@ -63,7 +63,7 @@ it('has current page content', () => {
   expect(barba.data.current.namespace).toBe(namespace);
   expect(barba.data.current.url).toEqual({
     hash: undefined,
-    href: '/',
+    href: 'http://localhost/',
     path: '/',
     query: {},
   });
@@ -80,7 +80,7 @@ it('init history', () => {
       x: 0,
       y: 0,
     },
-    url: '/',
+    url: 'http://localhost/',
   });
 });
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -574,7 +574,7 @@ export class Core {
    * Set "current" and unset "next".
    */
   private _resetData() {
-    const href = this.url.getPath(this.url.getHref());
+    const href = this.url.getHref();
     const current = {
       container: this.dom.getContainer(),
       html: this.dom.getHtml(),


### PR DESCRIPTION
Added history feature clears the query params from URL on init.

For example. I clicked some link to my site with UTM query params: `https://website.com/page/subpage?utm_source=source&utm_medium=referral&utm_campaign=campaign`

Barba converts it to: `https://website.com/page/subpage`

and my trackers couldn't capture them and check the source.