### PR TITLE
fix(core): :bug: sameUrl now takes port into account

### DIFF
--- a/packages/core/src/modules/Prevent.ts
+++ b/packages/core/src/modules/Prevent.ts
@@ -90,7 +90,8 @@ const preventAll: PreventCheck = ({ el }) =>
  * > Not in the test suite.
  */
 const sameUrl: PreventCheck = ({ href }) =>
-  url.clean(href) === url.clean(window.location.href);
+  url.clean(href) === url.clean(window.location.href) &&
+  url.parsePort(href) === url.getPort();
 
 export class Prevent extends Ignore {
   public suite: string[] = [];

--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -87,6 +87,29 @@ export const parse = (url: string): IUrlBase => {
 };
 
 /**
+ * Parse the port in a url.
+ */
+export const parsePort = (str: string): number => {
+  const matches = str.match(/:\d+/);
+
+  if (matches != null) {
+    const portString = matches[0].substring(1);
+
+    return parseInt(portString, 10);
+  }
+
+  if (/^https/.test(str)) {
+    return 443;
+  }
+
+  if (/^http/.test(str)) {
+    return 80;
+  }
+
+  return getPort();
+};
+
+/**
  * Parse a query string to object.
  */
 export const parseQuery = (str: string) =>


### PR DESCRIPTION
Added the function parsePort, that extracts the port from a url, and implemented sameUrl using
parsePort to take port into account

Closes #463