### PR TITLE
getting started: correct syntax in custom rule example (for issue 491)

### DIFF
--- a/documentation/user/index.md
+++ b/documentation/user/index.md
@@ -93,8 +93,7 @@ barba.init({
     },
 
     // apply only if clicked link contains `.cta`
-    custom: ({ current, next, trigger })
-      => trigger.classList && trigger.classList.contains('cta'),
+    custom: ({ current, next, trigger }) => trigger.classList && trigger.classList.contains('cta'),
 
     // do leave and enter concurrently
     sync: true,


### PR DESCRIPTION
For #491 

The Getting Started docs include

```javascript
    custom: ({ current, next, trigger })
      => trigger.classList && trigger.classList.contains('cta'),
```

which gives the parsing error

```
Unexpected token, expected ","
```

Fix is to put it all on one line.