### PR TITLE
core syntax documentation copy edits and revisions

### DIFF
--- a/documentation/user/index.md
+++ b/documentation/user/index.md
@@ -56,13 +56,14 @@ or using a CDN:
 
 ## Getting started
 
-> See [@barba/core](https://barba.js.org/docs/v2/user/core.html) for more details…
+> See [@barba/core syntax documentation](https://barba.js.org/docs/userguide/syntax/) for more details…
+
+Basic default transition (with no rules and minimal hooks):
 
 ```js
 // do not import Barba like this if you load the library through the browser
 import barba from '@barba/core';
 
-// basic default transition (with no rules and minimal hooks)
 barba.init({
   transitions: [{
     leave({ current, next, trigger }) {
@@ -75,8 +76,11 @@ barba.init({
     }
   }]
 });
+```
 
-// dummy example to illustrate rules and hooks
+Example to illustrate rules and hooks:
+
+```javascript
 barba.init({
   transitions: [{
     name: 'dummy-transition',


### PR DESCRIPTION
I looked at the v2 syntax documentation a few weeks ago, and found it hard to follow. Today I worked through it, changing things to help myself understand. This PR has all those changes.

I'm afraid it's all one big commit — I started at the top and read through. It's mostly:

- add a table of the transition properties
- add "transitions" to the heading names of things under Transitions, to help keep track of the section heirarchy
- move the `data` docs out from under Transitions
- some copy edits

There's a risk that this will feel inappropriately big! I know I'm new to this project, don't hesitate to say no to some or even all of it.

Thanks for a cool tool, I'm excited to try it out now that I get how it works 🎉