### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It helps reduce the delay between your pages, minimize browser HTTP requests and
 ## What's new?
 
 - Simplified API
-- Hook sytem for `transitions` and `views`
+- Hook system for `transitions` and `views`
 - _Transition resolution_: declare your transitions and let Barba pick the right one
 - Use of `data-barba` attributes
 - Sync mode

--- a/TODO.md
+++ b/TODO.md
@@ -55,4 +55,4 @@
   - [ ] Repo transfer?
     - [doc](https://help.github.com/articles/transferring-a-repository/)
     - [hack post](https://francisco.io/blog/transferring-github-stars/)
-  - VSCode extensions recommandations? settings?
+  - VSCode extensions recommendations? settings?

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -24,4 +24,4 @@ module.exports = (on, config) => {
     }
   });
 };
-/* eslint-enable consitent-return, no-unused-vars */
+/* eslint-enable consistent-return, no-unused-vars */


### PR DESCRIPTION
There are small typos in:
- README.md
- TODO.md
- cypress/plugins/index.js

Fixes:
- Should read `system` rather than `sytem`.
- Should read `recommendations` rather than `recommandations`.
- Should read `consistent` rather than `consitent`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md