### PR TITLE
chore(core): :rotating_light: Removing linter warnings

### DIFF
--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -132,7 +132,7 @@ export class Hooks extends HookMethods {
   public help(): void {
     this.logger.info(`Available hooks: ${this.all.join(',')}`);
     const registered: string[] = [];
-    this.registered.forEach((value, key) => registered.push(key));
+    this.registered.forEach((_value: any, key: string) => registered.push(key));
     this.logger.info(`Registered hooks: ${registered.join(',')}`);
   }
 }


### PR DESCRIPTION
Hello!
Small fix to the warnings by typing parameters. 
Adding an underscore to the first one since it's not used but necessary for order.

Thanks!